### PR TITLE
Amended'import json' statement in core.py

### DIFF
--- a/mfabrik/zoho/core.py
+++ b/mfabrik/zoho/core.py
@@ -26,7 +26,7 @@ except ImportError:
    
 
 try:
-    import json
+    import json as simplejson
 except ImportError:
     try:
         import simplejson


### PR DESCRIPTION
decode_json function assumed simplejson module, and caused errors if json module loaded.

amending 'import json' to 'import json as simplejson' avoids these errors.
